### PR TITLE
Allow remote database for app

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,6 +1,7 @@
-PGHOST=gopherdb
-PGPORT=5433
+PGHOST=0.0.0.0
+PGPORT=5432
 PGDATABASE=gopher
+PGUSER=postgres
 PGPASSWORD=postgres
 
 # A long, secret value used to encrypt the session cookie

--- a/db/index.ts
+++ b/db/index.ts
@@ -1,6 +1,6 @@
 import postgres from 'postgres';
 
-const sql = postgres('postgres://postgres:postgres@localhost:5433/gopher', {
+const sql = postgres({
   transform: {
     column: {
       to: postgres.fromCamel,

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,7 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  setupFiles: ['<rootDir>/server/test/global-setup.ts'],
   moduleNameMapper: {
     '^@/components/(.*)$': '<rootDir>/components/$1',
     '^@/pages/(.*)$': '<rootDir>/pages/$1',

--- a/package-lock.json
+++ b/package-lock.json
@@ -7256,6 +7256,21 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@next/swc-freebsd-x64": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.2.0.tgz",
+      "integrity": "sha512-gRiAw8g3Akf6niTDLEm1Emfa7jXDjvaAj/crDO8hKASKA4Y1fS4kbi/tyWw5VtoFI4mUzRmCPmZ8eL0tBSG58A==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   },
   "dependencies": {
@@ -12633,6 +12648,12 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
       "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
       "dev": true
+    },
+    "@next/swc-freebsd-x64": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.2.0.tgz",
+      "integrity": "sha512-gRiAw8g3Akf6niTDLEm1Emfa7jXDjvaAj/crDO8hKASKA4Y1fS4kbi/tyWw5VtoFI4mUzRmCPmZ8eL0tBSG58A==",
+      "optional": true
     }
   }
 }

--- a/pages/lists/index.tsx
+++ b/pages/lists/index.tsx
@@ -4,7 +4,6 @@ import type { List, User, ListItemEvent } from '@/types/index';
 import NewListForm from '@/components/NewListForm';
 import { getLists, getListItemEvents } from '@/server/lists/index';
 import { getUsers } from '@/server/users/index';
-import ListItemEdit from '@/components/ListItemEdit';
 
 interface Props {
   lists: List[];

--- a/server/test/global-setup.ts
+++ b/server/test/global-setup.ts
@@ -1,0 +1,7 @@
+process.env.PGHOST = 'localhost';
+process.env.PGPORT = '5433';
+process.env.PGDATABASE = 'gopher';
+process.env.PGUSER = 'postgres';
+process.env.PGPASSWORD = 'postgres';
+
+export {};

--- a/server/test/server.test.ts
+++ b/server/test/server.test.ts
@@ -467,7 +467,6 @@ describe('server', () => {
       });
 
       const listEvents = await getListItemEvents([listId]);
-      console.log(JSON.stringify(listEvents));
       expect(listEvents).toHaveLength(3);
       expect(listEvents[0].eventType).toEqual('delete');
       expect(listEvents[1].eventType).toEqual('modify');


### PR DESCRIPTION
Provide the remote database IP address as the DB host and port `5432` in your `.env.local` file in order to connect to the deployed database. Switch the port back to `5433` and remove the IP address/set it to local host in order to switch back to your local Docker database. After changing `.env.local` you'll have to restart your server to read the new values.